### PR TITLE
[IMP]Versión 9.0.3.0

### DIFF
--- a/__openerp__.py
+++ b/__openerp__.py
@@ -36,6 +36,8 @@
         'data/document_type.xml',
         'security/l10n_cl_invoice_security.xml',
         'wizard/journal_config_wizard_view.xml',
+        'wizard/notas.xml',
+        'data/product.xml',
         'data/responsability.xml',
         'data/sii.document_letter.csv',
         'data/sii.document_class.csv',
@@ -67,5 +69,5 @@
         'data/tax.xml',
         #'views/sii_menuitem.xml',
     ],
-    'version': '9.0.2.0',
+    'version': '9.0.3.0',
 }

--- a/__openerp__.py
+++ b/__openerp__.py
@@ -64,7 +64,8 @@
         'security/ir.model.access.csv',
         'security/l10n_cl_invoice_security.xml',
         'data/res.currency.csv',
+        'data/tax.xml',
         #'views/sii_menuitem.xml',
     ],
-    'version': '9.0.1.1',
+    'version': '9.0.2.0',
 }

--- a/data/product.xml
+++ b/data/product.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<openerp>
+    <record id="no_product" model="product.template">
+      <field name="name">Modifica Documento</field>
+      <field name="default_code">NO_PRODUCT</field>
+      <field name="lst_price">0</field>
+      <field name="taxes_ids" eval="False" />
+    </record>
+</openerp>

--- a/data/tax.xml
+++ b/data/tax.xml
@@ -10,6 +10,7 @@
       <field name="chart_template_id" ref="l10n_cl.cl_chart_template"/>
       <field name="sii_code">15</field>
       <field name="name">Retención Total IVA</field>
+      <field name="description">Retención</field>
       <field name="amount">19</field>
       <field name="amount_type">percent</field>
       <field name="type_tax_use">purchase</field>
@@ -17,5 +18,27 @@
       <field name="account_id" ref="l10n_cl.231"/>
       <field name="sii_type" >R</field>
       <field name="retencion">19.000</field>
+    </record>
+    <record id="exento_compra" model="account.tax.template">
+      <field name="chart_template_id" ref="l10n_cl.cl_chart_template"/>
+      <field name="sii_code">0</field>
+      <field name="name">Exento Compra</field>
+      <field name="description">Exento</field>
+      <field name="amount">0</field>
+      <field name="amount_type">percent</field>
+      <field name="type_tax_use">purchase</field>
+      <field name="refund_account_id" ref="l10n_cl.231"/>
+      <field name="account_id" ref="l10n_cl.231"/>
+    </record>
+    <record id="exento_venta" model="account.tax.template">
+      <field name="chart_template_id" ref="l10n_cl.cl_chart_template"/>
+      <field name="sii_code">0</field>
+      <field name="name">Exento Venta</field>
+      <field name="description">Exento</field>
+      <field name="amount">0</field>
+      <field name="amount_type">percent</field>
+      <field name="type_tax_use">sale</field>
+      <field name="refund_account_id" ref="l10n_cl.231"/>
+      <field name="account_id" ref="l10n_cl.231"/>
     </record>
 </openerp>

--- a/data/tax.xml
+++ b/data/tax.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="utf-8"?>
+<openerp>
+    <record id="l10n_cl.OTAX_19" model="account.tax.template">
+      <field name="sii_code">14</field>
+    </record>
+    <record id="l10n_cl.OTAX_19" model="account.tax.template">
+      <field name="sii_code">14</field>
+    </record>
+    <record id="retencion_iva" model="account.tax.template">
+      <field name="chart_template_id" ref="l10n_cl.cl_chart_template"/>
+      <field name="sii_code">15</field>
+      <field name="name">Retención Total IVA</field>
+      <field name="amount">19</field>
+      <field name="amount_type">percent</field>
+      <field name="type_tax_use">purchase</field>
+      <field name="refund_account_id" ref="l10n_cl.231"/>
+      <field name="account_id" ref="l10n_cl.231"/>
+      <field name="sii_type" >R</field>
+      <field name="retencion">19.000</field>
+    </record>
+</openerp>

--- a/data/tax.xml
+++ b/data/tax.xml
@@ -41,4 +41,16 @@
       <field name="refund_account_id" ref="l10n_cl.231"/>
       <field name="account_id" ref="l10n_cl.231"/>
     </record>
+    <record id="especifico_compra" model="account.tax.template">
+      <field name="chart_template_id" ref="l10n_cl.cl_chart_template"/>
+      <field name="sii_code">29</field>
+      <field name="name">Específico Compra</field>
+      <field name="description">Especifico</field>
+      <field name="amount">63</field>
+      <field name="amount_type">percent</field>
+      <field name="type_tax_use">purchase</field>
+      <field name="no_rec" eval="True" />
+      <field name="refund_account_id" ref="l10n_cl.231"/>
+      <field name="account_id" ref="l10n_cl.231"/>
+    </record>
 </openerp>

--- a/i18n/es_CL.po
+++ b/i18n/es_CL.po
@@ -7,16 +7,14 @@ msgstr ""
 "Project-Id-Version: l10n_cl_invoice - Odoo V8\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2016-03-21 19:58+0000\n"
-"PO-Revision-Date: 2016-03-21 17:06-0300\n"
-"Last-Translator: Daniel Blanco - Blanco Martín & Asociados "
-"<daniel@blancomartin.cl>\n"
+"PO-Revision-Date: 2016-10-06 21:17-0300\n"
+"Last-Translator: Daniel Santibáñez Polanco <dansanti@gmail.cm>\n"
 "Language-Team: Blanco Martín & Asociados <info@blancomartin.cl>\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"X-Generator: Poedit 1.5.4\n"
 "Language: es_CL\n"
-"X-Poedit-SourceCharset: UTF-8\n"
+"X-Generator: Poedit 1.8.7.1\n"
 
 #. module: l10n_cl_invoice
 #: help:account.journal.document_config,weird_documents:0
@@ -136,8 +134,7 @@ msgstr "Creado por"
 #: field:sii.concept_type,create_date:0 field:sii.document_class,create_date:0
 #: field:sii.document_letter,create_date:0
 #: field:sii.document_type,create_date:0 field:sii.optional_type,create_date:0
-#: field:sii.point_of_sale,create_date:0
-#: field:sii.responsability,create_date:0
+#: field:sii.point_of_sale,create_date:0 field:sii.responsability,create_date:0
 #, fuzzy
 msgid "Created on"
 msgstr "Creado en"
@@ -318,9 +315,8 @@ msgstr "Giros de La Compañia"
 
 #. module: l10n_cl_invoice
 #: view:account.journal:l10n_cl_invoice.view_account_journal_cl_form
-#, fuzzy
 msgid "Giros del Diario"
-msgstr " D, <borrar>, <supr>  Borrar una entrada"
+msgstr "Giros del Diario"
 
 #. module: l10n_cl_invoice
 #: view:res.partner:l10n_cl_invoice.view_res_partner_form
@@ -354,9 +350,8 @@ msgstr ""
 
 #. module: l10n_cl_invoice
 #: model:ir.model,name:l10n_cl_invoice.model_account_invoice
-#, fuzzy
 msgid "Invoice"
-msgstr "Documento de Salida"
+msgstr "Factura"
 
 #. module: l10n_cl_invoice
 #: model:ir.model,name:l10n_cl_invoice.model_account_invoice_line
@@ -428,15 +423,13 @@ msgstr "Documentos Tributarios SII del Diario"
 
 #. module: l10n_cl_invoice
 #: field:account.journal,journal_activities_ids:0
-#, fuzzy
 msgid "Journal Turns"
-msgstr "%s: recuperando el fichero de transacciones\n"
+msgstr "Giros del Diario"
 
 #. module: l10n_cl_invoice
 #: field:partner.activities,journal_ids:0
-#, fuzzy
 msgid "Journals"
-msgstr "Libros"
+msgstr "Diarios"
 
 #. module: l10n_cl_invoice
 #: field:account.journal.document_config,write_uid:0
@@ -622,9 +615,8 @@ msgstr "Receptores"
 
 #. module: l10n_cl_invoice
 #: view:account.invoice:l10n_cl_invoice.view_invoice_form
-#, fuzzy
 msgid "Refund Invoice"
-msgstr "Nota de Cŕedito"
+msgstr "Nota de Crédito o Débito"
 
 #. module: l10n_cl_invoice
 #: field:account.journal.document_config,dte_register:0
@@ -639,15 +631,13 @@ msgstr "Registra Documentos de Zona Franca o Resolución #1057?"
 
 #. module: l10n_cl_invoice
 #: field:account.journal.document_config,non_dte_register:0
-#, fuzzy
 msgid "Register Manual Documents?"
-msgstr "¿Registra Documentos Tributarios Electrónicos?"
+msgstr "¿Registra Documentos Tributarios Manuales?"
 
 #. module: l10n_cl_invoice
 #: field:account.journal.document_config,settlement_invoice:0
-#, fuzzy
 msgid "Register Settlement Invoices?"
-msgstr "¿Registra Documentos Tributarios Electrónicos?"
+msgstr "¿Registra Facturas de Liquidación?"
 
 #. module: l10n_cl_invoice
 #: model:ir.ui.menu,name:l10n_cl_invoice.menu_action_sii_responsability

--- a/models/account.py
+++ b/models/account.py
@@ -7,12 +7,13 @@ import logging
 _logger = logging.getLogger(__name__)
 
 
-class sii_tax_code(models.Model):
+class SiiTaxCode(models.Model):
     _inherit = 'account.tax'
 
     sii_code = new_fields.Integer('SII Code')
     sii_type = new_fields.Selection([ ('A','Anticipado'),('R','Retención')], string="Tipo de impuesto para el SII")
     retencion = new_fields.Float(string="Valor retención", default=0.00)
+    no_rec = new_fields.Boolean(string="Es No Recuperable")#esto es distinto al código no recuperable, depende del manejo de recuperación de impuesto
 
     @api.v8
     def compute_all(self, price_unit, currency=None, quantity=1.0, product=None, partner=None, discount=None):
@@ -117,7 +118,7 @@ class sii_tax_code(models.Model):
                 neto = int(base_amount / (1 + self.amount / 100))
             iva = base_amount - neto
             return iva
-        return super(sii_tax_code,self)._compute_amount(base_amount, price_unit, quantity, product, partner)
+        return super(SiiTaxCode,self)._compute_amount(base_amount, price_unit, quantity, product, partner)
 
 class account_move(models.Model):
     _inherit = "account.move"

--- a/models/account.py
+++ b/models/account.py
@@ -92,7 +92,7 @@ class sii_tax_code(models.Model):
                 'refund_account_id': tax.refund_account_id.id,
                 'analytic': tax.analytic,
             })
-        
+
 
         return {
             'taxes': sorted(taxes, key=lambda k: k['sequence']),
@@ -100,6 +100,16 @@ class sii_tax_code(models.Model):
             'total_included': currency.round(total_included) if bool(self.env.context.get("round", True)) else total_included,
             'base': base,
             }
+
+    def _compute_amount(self, base_amount, price_unit, quantity=1.0, product=None, partner=None):
+        if self.amount_type == 'percent' and self.price_include:
+            neto = round(base_amount / (1 + self.amount / 100))
+            iva_round =  round(neto * ( self.amount / 100))
+            if round(neto+iva_round) != round(base_amount):
+                neto = int(base_amount / (1 + self.amount / 100))
+            iva = base_amount - neto
+            return iva
+        return super(sii_tax_code,self)._compute_amount(base_amount, price_unit, quantity, product, partner)
 
 class account_move(models.Model):
     _inherit = "account.move"

--- a/models/account.py
+++ b/models/account.py
@@ -80,6 +80,9 @@ class sii_tax_code(models.Model):
             else:
                 total_included += tax_amount
 
+            # Keep base amount used for the current tax
+            tax_base = base
+
             if tax.include_base_amount:
                 base += tax_amount
 
@@ -87,6 +90,7 @@ class sii_tax_code(models.Model):
                 'id': tax.id,
                 'name': tax.with_context(**{'lang': partner.lang} if partner else {}).name,
                 'amount': tax_amount,
+                'base': tax_base,
                 'sequence': tax.sequence,
                 'account_id': tax.account_id.id,
                 'refund_account_id': tax.refund_account_id.id,

--- a/models/invoice.py
+++ b/models/invoice.py
@@ -37,7 +37,11 @@ class AccountInvoiceTax(models.Model):
                 base = 0.0
                 for line in tax.invoice_id.invoice_line_ids:
                     if tax.tax_id in line.invoice_line_tax_ids:
-                        base += (line.price_tax_included / (1 + tax.tax_id.amount / 100)) # valor sin redondeo
+                        neto = round(line.price_tax_included / (1 + tax.tax_id.amount / 100))
+                        iva_round =  round(neto * ( tax.tax_id.amount / 100))
+                        if round(neto+iva_round) != round(line.price_tax_included):
+                            neto = int(line.price_tax_included / (1 + tax.tax_id.amount / 100))
+                        base += neto
                         base += sum((line.invoice_line_tax_ids.filtered(lambda t: t.include_base_amount) - tax.tax_id).mapped('amount'))
                 tax.base = tax.invoice_id.currency_id.round(base)# se redondea global
             else:

--- a/models/invoice.py
+++ b/models/invoice.py
@@ -125,7 +125,7 @@ class account_invoice(models.Model):
         return recs.name_get()
 
     @api.onchange('journal_id', 'partner_id', 'turn_issuer','invoice_turn')
-    def _get_available_journal_document_class(self):
+    def _get_available_journal_document_class(self, default=None):
         for inv in self:
             invoice_type = inv.type
             document_class_ids = []
@@ -180,7 +180,11 @@ class account_invoice(models.Model):
                     inv.available_journals = []
 
             inv.available_journal_document_class_ids = document_class_ids
-            if not inv.journal_document_class_id:
+            if not inv.journal_document_class_id or default:
+                if default:
+                    for dc in document_classes:
+                        if dc.sii_document_class_id.id == default:
+                            document_class_id = dc.id
                 inv.journal_document_class_id = document_class_id
 
     @api.onchange('sii_document_class_id')

--- a/models/invoice.py
+++ b/models/invoice.py
@@ -70,7 +70,8 @@ class account_invoice(models.Model):
                     amount_total += line.price_tax_included
 
             inv.amount_tax = sum(line.amount for line in inv.tax_line_ids)
-            inv.amount_untaxed = currency.round(amount_total - inv.amount_tax)
+            bases = sum(line.base for line in inv.tax_line_ids)
+            inv.amount_untaxed = bases
             inv.amount_total = inv.amount_untaxed + inv.amount_tax
             amount_total_company_signed = inv.amount_total
             amount_untaxed_signed = inv.amount_untaxed

--- a/views/account_tax.xml
+++ b/views/account_tax.xml
@@ -9,6 +9,7 @@
                 <field name="sii_code" />
                 <field name="sii_type" />
                 <field name="retencion" attrs="{'required':[('sii_type','in',['R'])], 'invisible':[('sii_type','=',False)]}" />
+                <field name="no_rec" />
             </field>
 
         </field>
@@ -22,6 +23,8 @@
             <field name="name" position="before">
                 <field name="sii_code" />
                 <field name="sii_type" />
+                <field name="retencion" />
+                <field name="no_rec" />
             </field>
         </field>
     </record>

--- a/views/invoice_view.xml
+++ b/views/invoice_view.xml
@@ -45,6 +45,12 @@
             <field name="model">account.invoice</field>
             <field name="inherit_id" ref="account.invoice_form"/>
             <field name="arch" type="xml">
+              <button name="invoice_cancel" position="attributes">
+                  <attribute name="invisible">1</attribute>
+              </button>
+              <field name="state" position="before">
+                <button name="%(account.action_account_invoice_refund)d" type='action' string='Refund Invoice' groups="base.group_user" attrs="{'invisible': ['|',('type', '=', 'out_invoice'), ('state', 'not in', ('open','proforma2','paid'))]}"/>
+              </field>
                <xpath expr="//page/field[@name='invoice_line_ids']/tree/field[@name='product_id']" position="after">
                  <field name="name" />
                </xpath>
@@ -134,6 +140,12 @@
             <field name="model">account.invoice</field>
             <field name="inherit_id" ref="account.invoice_supplier_form"/>
             <field name="arch" type="xml">
+              <button name="invoice_cancel" position="attributes">
+                  <attribute name="invisible">1</attribute>
+              </button>
+              <field name="state" position="before">
+                <button name="%(account.action_account_invoice_refund)d" type='action' string='Ask Refund' groups="account.group_account_invoice" attrs="{'invisible': ['|',('type', '=', 'in_invoice'),('state','not in',('open','paid'))]}"/>
+              </field>
                 <form>
                     <field name="available_journal_document_class_ids" invisible="1"/>
                     <field name="use_documents" invisible="1"/>

--- a/views/partner_view.xml
+++ b/views/partner_view.xml
@@ -35,13 +35,15 @@
                     <attribute name="attrs">{'invisible':1}</attribute>
                 </field>
 
-                <field name="partner_activities_ids" position="replace">
+                <field name="partner_activities_ids" position="before">
                     <field name="tp_sii_code" invisible="True"/>
                     <field name="partner_activities_ids"
                         placeholder="Giros del Partner" widget="many2many_tags"
                         options="{'no_create': True}"
                         domain="[('parent_id', '>=', 1),
-                        ('tax_category', '=', tp_sii_code)]"/>
+                        ('tax_category', '=', tp_sii_code)]"
+                        invisible="True"/>
+                        <!-- posiblemente marcado como obsoleto, ya que se necesita el giro tipo sii solamente en la compañia-->
                 </field>
 
             </field>

--- a/wizard/__init__.py
+++ b/wizard/__init__.py
@@ -20,5 +20,4 @@
 ##############################################################################
 
 from . import journal_config_wizard
-
-# vim:expandtab:smartindent:tabstop=4:softtabstop=4:shiftwidth=4:
+from . import notas

--- a/wizard/notas.py
+++ b/wizard/notas.py
@@ -1,0 +1,111 @@
+# -*- coding: utf-8 -*-
+
+from openerp import models, fields, api, _
+from openerp.tools.safe_eval import safe_eval as eval
+from openerp.exceptions import UserError
+
+
+class AccountInvoiceRefund(models.TransientModel):
+    """Refunds invoice"""
+
+    _inherit = "account.invoice.refund"
+
+    tipo_nota = fields.Many2one('sii.document_class', string="Tipo De nota", required=True, domain=[('document_type','in',['debit_note','credit_note']), ('dte','=',True)])
+    filter_refund = fields.Selection([
+                ('1','Anula Documento de Referencia'),
+                ('2','Corrige texto Documento Referencia'),
+                ('3','Corrige montos')
+                ],
+                default='1',
+                string='Refund Method',
+                required=True, help='Refund base on this type. You can not Modify and Cancel if the invoice is already reconciled')
+
+    @api.multi
+    def compute_refund(self, mode='refund'):
+        inv_obj = self.env['account.invoice']
+        inv_tax_obj = self.env['account.invoice.tax']
+        inv_line_obj = self.env['account.invoice.line']
+        inv_reference_obj = self.env['account.invoice.referencias']
+        context = dict(self._context or {})
+        xml_id = False
+
+
+        for form in self:
+            created_inv = []
+            date = False
+            description = False
+            tipo_nota = form.tipo_nota
+            for inv in inv_obj.browse(context.get('active_ids')):
+                if inv.state in ['draft', 'proforma2', 'cancel']:
+                    raise UserError(_('Cannot refund draft/proforma/cancelled invoice.'))
+                if inv.reconciled and inv.amount_total > 0:
+                    raise UserError(_('Cannot refund invoice which is already reconciled, invoice should be unreconciled first. You can only refund this invoice.'))
+
+                date = form.date or False
+                description = form.description or inv.name
+                if mode in ['2']:
+                    invoice = inv.read(
+                                ['name', 'type', 'number', 'reference',
+                                    'comment', 'date_due', 'partner_id',
+                                    'partner_insite', 'partner_contact',
+                                    'partner_ref', 'payment_term_id', 'account_id',
+                                    'currency_id', 'invoice_line_ids',
+                                    'journal_id', 'date'])
+                    invoice = invoice[0]
+                    del invoice['id']
+                    prod = self.env['product.product'].search([('product_tmpl_id','=',self.env.ref('l10n_cl_invoice.no_product').id)])
+                    account = inv.invoice_line_ids.get_invoice_line_account(inv.type, prod, inv.fiscal_position_id, inv.company_id)
+                    invoice.update({
+                        'type': inv.type,
+                        'date_invoice': date,
+                        'state': 'draft',
+                        'number': False,
+                        'invoice_line_ids': [[5,],[0,0, {
+                                                    'product_id' : prod.id,
+                                                    'account_id': account.id,
+                                                    'name' : prod.name,
+                                                    'quantity' : 0, 
+                                                    'price_unit' : 0
+                                                    }]],
+                        'date': date,
+                        'name': description,
+                        'origin': inv.origin,
+                    })
+
+                    for field in ('partner_id', 'account_id', 'currency_id',
+                                         'payment_term_id', 'journal_id'):
+                            invoice[field] = invoice[field] and invoice[field][0]
+                    refund = inv_obj.create(invoice)
+                    if refund.payment_term_id.id:
+                        refund._onchange_payment_term_date_invoice()
+                if mode in ['1','3']:
+                    refund = inv.refund(form.date_invoice, date, description, inv.journal_id.id)
+                    refund.compute_taxes()
+                refund._get_available_journal_document_class(tipo_nota.id)
+                created_inv.append(refund.id)
+                refund.update({
+                    'turn_issuer': inv.turn_issuer.id,
+                })
+                if inv.type in ['out_invoice','out_refund']:
+                    refund.update({
+                        'referencias':[[5,],[0,0, {
+                                                    'origen':inv.sii_document_number,
+                                                    'sii_referencia_TpoDocRef': inv.sii_document_class_id.id,
+                                                    'sii_referencia_CodRef': mode,
+                                                    'motivo': description,
+                                                    'fecha_documento': inv.date_invoice
+                                                }]],
+                    })
+                xml_id = (inv.type in ['out_refund', 'out_invoice']) and 'action_invoice_tree1' or \
+                         (inv.type in ['in_refund', 'in_invoice']) and 'action_invoice_tree2'
+                # Put the reason in the chatter
+                subject = _("Invoice refund")
+                body = description
+                refund.message_post(body=body, subject=subject)
+        if xml_id:
+            result = self.env.ref('account.%s' % (xml_id)).read()[0]
+            invoice_domain = eval(result['domain'])
+            invoice_domain.append(('id', 'in', created_inv))
+            result['domain'] = invoice_domain
+            return result
+        return True

--- a/wizard/notas.py
+++ b/wizard/notas.py
@@ -54,9 +54,9 @@ class AccountInvoiceRefund(models.TransientModel):
                     prod = self.env['product.product'].search([('product_tmpl_id','=',self.env.ref('l10n_cl_invoice.no_product').id)])
                     account = inv.invoice_line_ids.get_invoice_line_account(inv.type, prod, inv.fiscal_position_id, inv.company_id)
                     type = inv.type
-                    if inv.type in [ 'out_invoice']:
+                    if inv.type in [ 'out_invoice','out_refund']:
                         type = 'out_refund'
-                    elif inv.type in ['in_invoice']:
+                    elif inv.type in ['in_invoice','in_refund']:
                         type = 'in_refund'
                     invoice.update({
                         'type': type,

--- a/wizard/notas.py
+++ b/wizard/notas.py
@@ -54,7 +54,7 @@ class AccountInvoiceRefund(models.TransientModel):
                     prod = self.env['product.product'].search([('product_tmpl_id','=',self.env.ref('l10n_cl_invoice.no_product').id)])
                     account = inv.invoice_line_ids.get_invoice_line_account(inv.type, prod, inv.fiscal_position_id, inv.company_id)
                     type = inv.type
-                    if inv.type in [ 'out_invoice']
+                    if inv.type in [ 'out_invoice']:
                         type = 'out_refund'
                     elif inv.type in ['in_invoice']:
                         type = 'in_refund'

--- a/wizard/notas.py
+++ b/wizard/notas.py
@@ -92,7 +92,7 @@ class AccountInvoiceRefund(models.TransientModel):
                 if inv.type in ['out_invoice','out_refund']:
                     refund.update({
                         'referencias':[[5,],[0,0, {
-                                                    'origen':inv.sii_document_number,
+                                                    'origen': int(inv.sii_document_number),
                                                     'sii_referencia_TpoDocRef': inv.sii_document_class_id.id,
                                                     'sii_referencia_CodRef': mode,
                                                     'motivo': description,

--- a/wizard/notas.py
+++ b/wizard/notas.py
@@ -53,13 +53,7 @@ class AccountInvoiceRefund(models.TransientModel):
                     del invoice['id']
                     prod = self.env['product.product'].search([('product_tmpl_id','=',self.env.ref('l10n_cl_invoice.no_product').id)])
                     account = inv.invoice_line_ids.get_invoice_line_account(inv.type, prod, inv.fiscal_position_id, inv.company_id)
-                    type = inv.type
-                    if inv.type in [ 'out_invoice','out_refund']:
-                        type = 'out_refund'
-                    elif inv.type in ['in_invoice','in_refund']:
-                        type = 'in_refund'
                     invoice.update({
-                        'type': type,
                         'date_invoice': date,
                         'state': 'draft',
                         'number': False,
@@ -74,7 +68,6 @@ class AccountInvoiceRefund(models.TransientModel):
                         'name': description,
                         'origin': inv.origin,
                     })
-
                     for field in ('partner_id', 'account_id', 'currency_id',
                                          'payment_term_id', 'journal_id'):
                             invoice[field] = invoice[field] and invoice[field][0]
@@ -84,6 +77,11 @@ class AccountInvoiceRefund(models.TransientModel):
                 if mode in ['1','3']:
                     refund = inv.refund(form.date_invoice, date, description, inv.journal_id.id)
                     refund.compute_taxes()
+                type = inv.type
+                if inv.type in [ 'out_invoice','out_refund']:
+                    refund.type = 'out_refund'
+                elif inv.type in ['in_invoice','in_refund']:
+                    refund.type = 'in_refund'
                 refund._get_available_journal_document_class(tipo_nota.id)
                 created_inv.append(refund.id)
                 refund.update({

--- a/wizard/notas.py
+++ b/wizard/notas.py
@@ -28,8 +28,6 @@ class AccountInvoiceRefund(models.TransientModel):
         inv_reference_obj = self.env['account.invoice.referencias']
         context = dict(self._context or {})
         xml_id = False
-
-
         for form in self:
             created_inv = []
             date = False
@@ -55,8 +53,13 @@ class AccountInvoiceRefund(models.TransientModel):
                     del invoice['id']
                     prod = self.env['product.product'].search([('product_tmpl_id','=',self.env.ref('l10n_cl_invoice.no_product').id)])
                     account = inv.invoice_line_ids.get_invoice_line_account(inv.type, prod, inv.fiscal_position_id, inv.company_id)
+                    type = inv.type
+                    if inv.type in [ 'out_invoice']
+                        type = 'out_refund'
+                    elif inv.type in ['in_invoice']:
+                        type = 'in_refund'
                     invoice.update({
-                        'type': inv.type,
+                        'type': type,
                         'date_invoice': date,
                         'state': 'draft',
                         'number': False,
@@ -64,7 +67,7 @@ class AccountInvoiceRefund(models.TransientModel):
                                                     'product_id' : prod.id,
                                                     'account_id': account.id,
                                                     'name' : prod.name,
-                                                    'quantity' : 0, 
+                                                    'quantity' : 0,
                                                     'price_unit' : 0
                                                     }]],
                         'date': date,

--- a/wizard/notas.xml
+++ b/wizard/notas.xml
@@ -1,0 +1,57 @@
+<?xml version="1.0" encoding="utf-8"?>
+<openerp>
+    <data>
+
+        <record id="view_account_invoice_notas" model="ir.ui.view">
+            <field name="name">account.invoice.refun.form</field>
+            <field name="model">account.invoice.refund</field>
+            <field name="inherit_id" ref="account.view_account_invoice_refund" />
+            <field name="arch" type="xml">
+                <form position="replace">
+                  <form string="Nota de Crédito / Débito">
+                    <group>
+                      <field name="tipo_nota" widget="radio"/>
+                    </group>
+                    <group>
+                       <group>
+                           <field name="refund_only" invisible="1"/>
+                           <field name="filter_refund" attrs="{'invisible': [('refund_only','=',True)]}" widget="radio"/>
+                       </group>
+                       <group>
+                           <div attrs="{'invisible':['|',('refund_only','=',True),('filter_refund','&lt;&gt;','refund')]}" class="oe_grey" colspan="4">
+                              You will be able to edit and validate this
+                              credit note directly or keep it draft,
+                              waiting for the document to be issued by
+                              your supplier/customer.
+                           </div>
+                           <div attrs="{'invisible':['|',('refund_only','=',True),('filter_refund','&lt;&gt;','cancel')]}" class="oe_grey" colspan="4">
+                              Use this option if you want to cancel an invoice you should not
+                              have issued. The credit note will be created, validated and reconciled
+                              with the invoice. You will not be able to modify the credit note.
+                           </div>
+                           <div attrs="{'invisible':['|',('refund_only','=',True),('filter_refund','&lt;&gt;','modify')]}" class="oe_grey" colspan="4">
+                              Use this option if you want to cancel an invoice and create a new
+                              one. The credit note will be created, validated and reconciled
+                              with the current invoice. A new, draft, invoice will be created
+                              so that you can edit it.
+                           </div>
+                       </group>
+                       <group>
+                           <field name="description"/>
+                       </group>
+                       <group>
+                           <field name="date_invoice"/>
+                           <field name="date" groups="base.group_no_one"/>
+                       </group>
+                    </group>
+                    <footer>
+                        <button string='Crear Nota' name="invoice_refund" type="object" class="btn-primary"/>
+                        <button string="Cancelar" class="btn-default" special="cancel"/>
+                    </footer>
+                  </form>
+               </form>
+            </field>
+        </record>
+
+    </data>
+</openerp>


### PR DESCRIPTION
- Reparado algunos problemas con redondeos(se nesitan más test para estar 100% seguros de que está completamente reparado, no olvidar activar cáculo de iva global y no por línea).
- Se ingresa reemplaza wizard creación de factura rectificativa, por algo como lo solicita el SII.
- Al llenar wizard se llena línea de referena según selección.
- Se crea product NO_PRODUCT, para enviar flag de que es una nota de modificación de texto.
- En el caso de seleccionar la razón modificación de texto, se autoselecciona NO_PRODUCT
  -En el caso de seleccionar anulación o devolución de mercaderías, se conservan las líneas de producto.
- Se obreescribe lógia que no permite factura rectificativa para facturas rectificativa, de este modo se puede crear nota de débito a una nota de crédito (@TODO revisar posibles problemas y complementar en el caso de que se anula una nota de crédito de anulación de factura, en ese caso se debiera invalidar la nota y dejar efectiva la factura)
