### PR TITLE
[FIX] Valor no actualiza para Notas

### DIFF
--- a/models/invoice.py
+++ b/models/invoice.py
@@ -70,7 +70,7 @@ class account_invoice(models.Model):
                     amount_total += line.price_tax_included
 
             inv.amount_tax = sum(line.amount for line in inv.tax_line_ids)
-            bases = sum(line.base for line in inv.tax_line_ids)
+            bases = sum(line.price_subtotal for line in inv.invoice_line_ids)
             inv.amount_untaxed = bases
             inv.amount_total = inv.amount_untaxed + inv.amount_tax
             amount_total_company_signed = inv.amount_total


### PR DESCRIPTION
Este bug se genera porque se trata de mantener el valor de la base para los casos de que proveedor no redondea ejemplo iva $5,58 algunos proveedores no redondean a $6 sino que lo dejan en $5

@TODO analizar y crear excepción de redondeo, para estar todos en la misma base de redondeo , if (5,58 < 5,6) no_redondeo, tomo_parte_entera else redondeo