### PR TITLE
Replaced view sequence for external id issue

### DIFF
--- a/__openerp__.py
+++ b/__openerp__.py
@@ -48,6 +48,7 @@ Incluye:
         'data/country.xml',
         'data/sii.concept_type.csv',
         'data/decimal_precision_data.xml',
+        'wizard/journal_config_wizard_view.xml',
         'views/company_view.xml',
         'views/country_view.xml',
         'views/sii_document_letter_view.xml',
@@ -71,7 +72,6 @@ Incluye:
         'security/l10n_cl_invoice_security.xml',
         'data/res.currency.csv',
         #'views/sii_menuitem.xml',
-        'wizard/journal_config_wizard_view.xml',
     ],
     'version': '8.1.0.0',
 }


### PR DESCRIPTION
`action_account_journal_document_config_form` button from the `journal_view.xml` fails with external id issue due to the wrong sequencing of views in `openerp.py.`

Related issue ticket: [odoo/14705](https://github.com/odoo/odoo/issues/14705)

Traceback:
```
File "/opt/odoo/code_from_community_personal_repo/odoo/openerp/tools/convert.py", line 839, in model_id_get
    raise_if_not_found=raise_if_not_found)
File "/opt/odoo/code_from_community_personal_repo/odoo/openerp/api.py", line 268, in wrapper
    return old_api(self, *args, **kwargs)
File "/opt/odoo/code_from_community_personal_repo/odoo/openerp/addons/base/ir/ir_model.py", line 909, in xmlid_to_res_model_res_id
    return self.xmlid_lookup(cr, uid, xmlid)[1:3]
File "/opt/odoo/code_from_community_personal_repo/odoo/openerp/api.py", line 268, in wrapper
    return old_api(self, *args, **kwargs)
File "<string>", line 2, in xmlid_lookup
File "/opt/odoo/code_from_community_personal_repo/odoo/openerp/tools/cache.py", line 74, in lookup
    value = d[key] = self.method(*args, **kwargs)
File "/opt/odoo/code_from_community_personal_repo/odoo/openerp/addons/base/ir/ir_model.py", line 899, in xmlid_lookup
    raise ValueError('External ID not found in the system: %s' % (xmlid))
ParseError: "External ID not found in the system: l10n_cl_invoice.action_account_journal_document_config_form" while parsing /opt/odoo/code_from_community_personal_repo/contribution/l10n_cl_invoice/views/journal_view.xml:16, near
<record id="view_account_journal_cl_form" model="ir.ui.view">
            <field name="model">account.journal</field>
            <field name="name">account.journal.ar.form</field>
            <field name="inherit_id" ref="account.view_account_journal_form"/>
            <field name="arch" type="xml">
                <data><field name="type" position="after">
                    <field name="use_documents" attrs="{'invisible': [('type','not in',['purchase','sale','purchase_refund','sale_refund'])]}"/>
                </field>
                    
                <notebook position="inside">
                    <page string="Documents" attrs="{'invisible': ['|',('use_documents','=',False),('type','not in',['purchase','sale','purchase_refund','sale_refund'])]}">
                        <button name="%(action_account_journal_document_config_form)d" string="Create Journal Documents" type="action" context="{'type':type, 'excempt_documents': excempt_documents}"/>
                        <group>
                            <field name="point_of_sale_id" attrs="{'invisible': ['|',('type','not in',['sale','sale_refund'])],'required': [('use_documents','=',True),('type','in',['sale','sale_refund'])]}" context="{'default_company_id':company_id}"/>
                            <field name="point_of_sale" attrs="{'invisible': ['|',('type','not in',['sale','sale_refund'])]}"/>
                            <field name="journal_activities_ids" attrs="{'invisible': ['|',('type','not in',['purchase','sale','purchase_refund','sale_refund'])],'required': [('use_documents','=',True),('type','in',['sale','sale_refund'])]}" context="{'default_company_id':company_id}" placeholder="Giros del Diario" widget="many2many_tags" options="{'no_create': True}" domain="[('partner_ids', '=', company_id)]"/>
                            <field name="excempt_documents" readonly="True"/>
                            <!--attrs="{'readonly': [('type', 'like', 'sale')]}"-->
                        </group>
                        <field name="journal_document_class_ids" context="{'journal_type':type}"/>
                    </page>
                </notebook>
            </data></field>
        </record>
2016-12-16 08:28:33,686 11239 INFO 8demo werkzeug: 127.0.0.1 - - [16/Dec/2016 08:28:33] "POST /web/dataset/call_button HTTP/1.1" 200 -
```